### PR TITLE
Wrap foreign exports in parentheses

### DIFF
--- a/src/Effect/Ref.lua
+++ b/src/Effect/Ref.lua
@@ -1,23 +1,28 @@
-return {
-  _new = function(val) return function() return {value = val} end end,
-  newWithSelf = function(f)
+local function _new(val) return function() return {value = val} end end
+local function newWithSelf(f)
     return function()
       local ref = {value = nil}
       ref.value = f(ref)
       return ref
     end
-  end,
-  read = function(ref) return function() return ref.value end end,
-  modifyImpl = function(f)
-    return function(ref)
-      return function()
-        local t = f(ref.value)
-        ref.value = t.state
-        return t.value
-      end
+end
+local function read(ref) return function() return ref.value end end
+local function modifyImpl(f)
+  return function(ref)
+    return function()
+      local t = f(ref.value)
+      ref.value = t.state
+      return t.value
     end
-  end,
-  write = function(val)
-    return function(ref) return function() ref.value = val end end
   end
+end
+local function write(val)
+  return function(ref) return function() ref.value = val end end
+end
+return {
+  _new = (_new),
+  newWithSelf = (newWithSelf),
+  read = (read),
+  modifyImpl = (modifyImpl),
+  write = (write),
 }


### PR DESCRIPTION
This should fix https://github.com/Unisay/purescript-lua/issues/29

**Description of the change**

Wrap foreign export values in parentheses so they can be parsed by the pslua compiler.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)