### PR TITLE
chore: add treefmt formatting (nix fmt + pre-commit + CI check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,7 @@ jobs:
         run: if [ -f scripts/test ]; then nix develop -c bash ./scripts/test; fi
 
       - name: Luacheck
-        run: nix develop -c luacheck --quiet --std lua51 --no-unused-args src/
+        run: nix develop -c luacheck --quiet --std lua51 --no-unused-args --max-line-length 130 src/
+
+      - name: Format check
+        run: nix fmt && git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.*
 !/.gitignore
 !/.github/
+!/.tidyrc.json
+!/.lua-format
 /output/

--- a/.lua-format
+++ b/.lua-format
@@ -1,0 +1,10 @@
+# LuaFormatter config for the hand-written FFI under src/.
+# 2-space indent. Keep simple functions on one line; column_limit sits a few
+# columns under luacheck's 130 limit because lua-format under-counts the leading
+# indent and trailing comma, so this keeps every emitted line within 130.
+indent_width: 2
+use_tab: false
+column_limit: 126
+continuation_indent_width: 2
+keep_simple_function_one_line: true
+keep_simple_control_block_one_line: true

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "source",
+  "width": 80
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,21 @@ A PureScript→Lua FFI fork in the [`purescript-lua`](https://github.com/purescr
 
 ## Commands
 
-All commands run inside the nix dev shell:
-
 - Build: `nix develop -c ./scripts/build`
 - Test (only if the fork has `scripts/test`): `nix develop -c bash ./scripts/test`
-- Lint: `nix develop -c luacheck --quiet --std lua51 --no-unused-args src/`
+- Lint: `nix develop -c luacheck --quiet --std lua51 --no-unused-args --max-line-length 130 src/`
+- Format: `nix fmt` (check: `nix fmt && git diff --exit-code`)
+
+## Formatting
+
+`nix fmt` runs treefmt (`treefmt.nix`): nixfmt for Nix, `dhall format`, purs-tidy
+for `*.purs` (config in `.tidyrc.json`), and LuaFormatter for the `*.lua` FFI
+(config in `.lua-format`). LuaFormatter is used over StyLua because it keeps the
+parentheses pslua's foreign-file parser requires. The Lua line budget is 130
+columns, matching the `luacheck --max-line-length` above. The check is
+content-based (`nix fmt && git diff --exit-code`) rather than `treefmt --ci`,
+since the in-place formatters bump mtime even when content is unchanged, which
+trips treefmt's `--fail-on-change`. CI and the pre-commit hook use it.
 
 ## Lua 5.1 target
 

--- a/flake.lock
+++ b/flake.lock
@@ -740,7 +740,8 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "pslua": "pslua",
-        "purescript-overlay": "purescript-overlay"
+        "purescript-overlay": "purescript-overlay",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "stackage": {
@@ -801,6 +802,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,16 +9,33 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     pslua.url = "github:purescript-lua/purescript-lua";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, purescript-overlay, pslua }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      purescript-overlay,
+      pslua,
+      treefmt-nix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ purescript-overlay.overlays.default ];
         };
-      in {
+        treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+      in
+      {
+        formatter = treefmtEval.config.build.wrapper;
+        checks.formatting = treefmtEval.config.build.check self;
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
             dhall
@@ -31,8 +48,26 @@
             spago-bin.spago-0_21_0
             treefmt
           ];
+          # Install a content-based pre-commit hook. It compares the working
+          # tree diff before and after `nix fmt`, so it only objects to changes
+          # the formatter itself introduces (not the developer's existing
+          # unstaged work) and is not fooled by formatters that only bump mtime.
+          # Rewritten each shell entry to stay in sync with this flake.
+          shellHook = ''
+            hook=.git/hooks/pre-commit
+            if [ -d .git ]; then
+              printf '%s\n' \
+                '#!/usr/bin/env bash' \
+                'before=$(git diff)' \
+                'nix fmt >/dev/null 2>&1 || exit 0' \
+                '[ "$before" = "$(git diff)" ] || { echo "nix fmt changed files; re-stage them, then commit." >&2; exit 1; }' \
+                > "$hook"
+              chmod +x "$hook"
+            fi
+          '';
         };
-      });
+      }
+    );
 
   # --- Flake Local Nix Configuration ----------------------------
   nixConfig = {

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,5 +1,5 @@
 { name = "purescript-lua-refs"
-, dependencies = [ "effect", "prelude" ] 
+, dependencies = [ "effect", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 }

--- a/src/Effect/Ref.lua
+++ b/src/Effect/Ref.lua
@@ -17,7 +17,5 @@ return {
       end
     end
   end),
-  write = (function(val)
-    return function(ref) return function() ref.value = val end end
-  end)
+  write = (function(val) return function(ref) return function() ref.value = val end end end)
 }

--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -58,7 +58,8 @@ foreign import read :: forall s. Ref s -> Effect s
 modify' :: forall s b. (s -> { state :: s, value :: b }) -> Ref s -> Effect b
 modify' = modifyImpl
 
-foreign import modifyImpl :: forall s b. (s -> { state :: s, value :: b }) -> Ref s -> Effect b
+foreign import modifyImpl
+  :: forall s b. (s -> { state :: s, value :: b }) -> Ref s -> Effect b
 
 -- | Update the value of a mutable reference by applying a function
 -- | to the current value. The updated value is returned.

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,43 @@
+{ pkgs, ... }:
+{
+  projectRootFile = "flake.nix";
+
+  # Nix — RFC 166 formatter.
+  programs.nixfmt.enable = true;
+
+  # Dhall — spago.dhall / packages.dhall layout.
+  programs.dhall.enable = true;
+
+  # PureScript — purs-tidy is not a first-class treefmt program, so wire it via
+  # the generic mechanism. It picks up `.tidyrc.json` from the project root.
+  settings.formatter.purs-tidy = {
+    command = "${pkgs.purs-tidy}/bin/purs-tidy";
+    options = [ "format-in-place" ];
+    includes = [ "*.purs" ];
+  };
+
+  # Lua FFI — LuaFormatter keeps the parentheses pslua's foreign-file parser
+  # requires (unlike StyLua, which strips them). Config in `.lua-format`.
+  settings.formatter.lua-format = {
+    command = "${pkgs.luaformatter}/bin/lua-format";
+    options = [
+      "-i"
+      "-c"
+      ".lua-format"
+    ];
+    includes = [ "*.lua" ];
+  };
+
+  # Never format generated output or vendored trees.
+  settings.global.excludes = [
+    "dist/*"
+    "output/*"
+    ".spago/*"
+    "node_modules/*"
+    "*.lock"
+    "flake.lock"
+    "spago.lock"
+    ".tidyrc.json"
+    ".lua-format"
+  ];
+}


### PR DESCRIPTION
Roll the ecosystem formatting setup (ADR 0007, piloted in purescript-lua/purescript-lua-effect#6) onto this fork.

**Tooling.** Copies `treefmt.nix`/`.tidyrc.json`/`.lua-format` and wires treefmt-nix into the flake: `nix fmt` formats, `checks.formatting` is exposed, the dev shell installs a content-based pre-commit hook, and CI gains a format-check step. The check is content-based (`nix fmt && git diff --exit-code`) rather than `treefmt --ci`, since the in-place formatters bump mtime even when content is unchanged. LuaFormatter is kept over StyLua because it preserves the parentheses pslua's foreign-file parser requires; `luacheck --max-line-length` raised to 130 to match.

**Diff.** The bulk is the first `nix fmt` pass over `*.purs` and the `*.lua` FFI. Verified locally: build + `luacheck --max-line-length 130` green.